### PR TITLE
Add tag action to CI.

### DIFF
--- a/.github/workflows/agent-build.yaml
+++ b/.github/workflows/agent-build.yaml
@@ -18,6 +18,11 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/agent-build.yaml
+++ b/.github/workflows/agent-build.yaml
@@ -18,11 +18,6 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Bump version and push tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -37,7 +32,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/metalbear-co/ci-agent-build:latest
+            ghcr.io/metalbear-co/ci-agent-build:${{ GITHUB_SHA }}
 
   runtime:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Issue: [#1457](https://github.com/metalbear-co/mirrord/issues/1457)

Tag our docker images based on commit hash, so we can specify which version to use in mirrord CI.