### PR TITLE
add e2e setup action

### DIFF
--- a/e2e-setup-action/README.md
+++ b/e2e-setup-action/README.md
@@ -1,0 +1,6 @@
+# e2e-setup-action
+
+Used by mirrord & operator repository to run shared preparation:
+
+1. Setup minikube
+2. Build all test apps

--- a/e2e-setup-action/action.yaml
+++ b/e2e-setup-action/action.yaml
@@ -1,8 +1,18 @@
 name: 'Setup mirrord e2e environment'
 description: 'Install all required dependencies for mirrord e2e tests'
+inputs:
+  container-runtime:
+    description: 'Container runtime to setup with minikube'
+    default: 'containerd'
 runs:
   using: "composite"
   steps:
+    - name: start minikube
+      uses: medyagh/setup-minikube@master
+      with:
+        container-runtime: ${{ inputs.container-runtime }}
+        cpu: 'max'
+        memory: 'max'
     - uses: actions/setup-node@v3
       with:
         node-version: 14

--- a/e2e-setup-action/action.yaml
+++ b/e2e-setup-action/action.yaml
@@ -17,25 +17,25 @@ runs:
       shell: bash
     - uses: actions/setup-go@v3
       with:
-        go-version: "^1.18.0"
+        go-version: "1.18"
     - run: |
         go version
       shell: bash
     - run: | # Build Go test apps.
         ./scripts/build_go_apps.sh 18
       shell: bash
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
-        go-version: "^1.19.0"
+        go-version: "1.19"
     - run: |
         go version
       shell: bash
     - run: | # Build Go test apps.
         ./scripts/build_go_apps.sh 19
       shell: bash
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
-        go-version: "^1.20.0"
+        go-version: "1.20"
     - run: |
         go version
       shell: bash

--- a/e2e-setup-action/action.yaml
+++ b/e2e-setup-action/action.yaml
@@ -7,12 +7,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: start minikube
-      uses: medyagh/setup-minikube@master
-      with:
-        container-runtime: ${{ inputs.container-runtime }}
-        cpu: 'max'
-        memory: 'max'
     - uses: actions/setup-node@v3
       with:
         node-version: 14
@@ -60,3 +54,10 @@ runs:
         cd tests/rust-bypassed-unix-socket
         cargo build
       shell: bash
+    # start last thing, to have previous steps faster (no cpu in background)
+    - name: start minikube
+      uses: medyagh/setup-minikube@master
+      with:
+        container-runtime: ${{ inputs.container-runtime }}
+        cpu: 'max'
+        memory: 'max'

--- a/e2e-setup-action/action.yaml
+++ b/e2e-setup-action/action.yaml
@@ -14,8 +14,6 @@ runs:
     - uses: actions/setup-python@v3
     - run: pip3 install flask fastapi uvicorn[standard]
       shell: bash
-    - run: sudo apt-get update && sudo apt-get install -y curl
-      shell: bash
     - uses: actions/setup-go@v3
       with:
         go-version: "1.18.0"

--- a/e2e-setup-action/action.yaml
+++ b/e2e-setup-action/action.yaml
@@ -1,0 +1,57 @@
+name: 'Setup mirrord e2e environment'
+description: 'Install all required dependencies for mirrord e2e tests'
+runs:
+  using: "composite"
+  steps:
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: rustfmt
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 14
+    - run: npm install express
+      shell: bash
+    - uses: actions/setup-python@v3
+    - run: pip3 install flask fastapi uvicorn[standard]
+      shell: bash
+    - run: sudo apt-get update && sudo apt-get install -y curl
+      shell: bash
+    - uses: actions/setup-go@v3
+      with:
+        go-version: "1.18.0"
+    - run: |
+        go version
+      shell: bash
+    - run: | # Build Go test apps.
+        ./scripts/build_go_apps.sh 18
+      shell: bash
+    - uses: actions/setup-go@v3
+      with:
+        go-version: "1.19.0"
+    - run: |
+        go version
+      shell: bash
+    - run: | # Build Go test apps.
+        ./scripts/build_go_apps.sh 19
+      shell: bash
+    - uses: actions/setup-go@v3
+      with:
+        go-version: "1.20.0-rc.3"
+    - run: |
+        go version
+      shell: bash
+    - run: | # Build Go test apps.
+        ./scripts/build_go_apps.sh 20
+      shell: bash
+    - run: |
+        cd tests/rust-e2e-fileops
+        cargo build
+      shell: bash
+    - run: |
+        cd tests/rust-unix-socket-client
+        cargo build
+      shell: bash
+    - run: |
+        cd tests/rust-bypassed-unix-socket
+        cargo build
+      shell: bash

--- a/e2e-setup-action/action.yaml
+++ b/e2e-setup-action/action.yaml
@@ -3,9 +3,6 @@ description: 'Install all required dependencies for mirrord e2e tests'
 runs:
   using: "composite"
   steps:
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        components: rustfmt
     - uses: actions/setup-node@v3
       with:
         node-version: 14

--- a/e2e-setup-action/action.yaml
+++ b/e2e-setup-action/action.yaml
@@ -18,6 +18,7 @@ runs:
     - uses: actions/setup-go@v3
       with:
         go-version: "1.18"
+        cache-dependency-path: tests/go-e2e/go.sum
     - run: |
         go version
       shell: bash
@@ -27,6 +28,7 @@ runs:
     - uses: actions/setup-go@v4
       with:
         go-version: "1.19"
+        cache-dependency-path: tests/go-e2e/go.sum
     - run: |
         go version
       shell: bash
@@ -36,6 +38,7 @@ runs:
     - uses: actions/setup-go@v4
       with:
         go-version: "1.20"
+        cache-dependency-path: tests/go-e2e/go.sum
     - run: |
         go version
       shell: bash

--- a/e2e-setup-action/action.yaml
+++ b/e2e-setup-action/action.yaml
@@ -59,5 +59,5 @@ runs:
       uses: medyagh/setup-minikube@master
       with:
         container-runtime: ${{ inputs.container-runtime }}
-        cpu: 'max'
+        cpus: 'max'
         memory: 'max'

--- a/e2e-setup-action/action.yaml
+++ b/e2e-setup-action/action.yaml
@@ -16,7 +16,7 @@ runs:
       shell: bash
     - uses: actions/setup-go@v3
       with:
-        go-version: "1.18.0"
+        go-version: "^1.18.0"
     - run: |
         go version
       shell: bash
@@ -25,7 +25,7 @@ runs:
       shell: bash
     - uses: actions/setup-go@v3
       with:
-        go-version: "1.19.0"
+        go-version: "^1.19.0"
     - run: |
         go version
       shell: bash
@@ -34,7 +34,7 @@ runs:
       shell: bash
     - uses: actions/setup-go@v3
       with:
-        go-version: "1.20.0-rc.3"
+        go-version: "^1.20.0"
     - run: |
         go version
       shell: bash


### PR DESCRIPTION
Used by mirrord & operator repository to run shared preparation:

1. Setup minikube
2. Build all test apps
