### PR TITLE
Don't build mirrord tests package

### DIFF
--- a/e2e-setup-action/action.yaml
+++ b/e2e-setup-action/action.yaml
@@ -63,8 +63,9 @@ runs:
     - run: | # Build Go test apps.
         ./scripts/build_go_apps.sh 21
       shell: bash
-    - run: | # Build Rust test apps.
-        for cargo_dir in $(find tests -name Cargo.toml -printf '%h\n'); do
+    - name: Build Rust test apps
+      run: |
+        for cargo_dir in $(find tests/*/* -name Cargo.toml -printf '%h\n'); do
             echo "Building test app in: $cargo_dir"
             pushd "$cargo_dir"
             cargo build

--- a/e2e-setup-action/action.yaml
+++ b/e2e-setup-action/action.yaml
@@ -78,4 +78,4 @@ runs:
       with:
         container-runtime: ${{ inputs.container-runtime }}
         cpus: 'max'
-        memory: 'max'
+        memory: '4gb'


### PR DESCRIPTION
`e2e-setup-action` builds the `tests` package in of the mirrord repo. This is completely unnecessary and [takes 4 minutes to complete](https://github.com/metalbear-co/operator/actions/runs/7886471993/job/21520250404#step:7:1324). 