### PR TITLE
Add step to build C test apps

### DIFF
--- a/e2e-setup-action/action.yaml
+++ b/e2e-setup-action/action.yaml
@@ -72,6 +72,9 @@ runs:
             popd
         done
       shell: bash
+    - name: Build C test apps
+      run: ./scripts/build_c_apps.sh
+      shell: bash
     # start last thing, to have previous steps faster (no cpu in background)
     - name: start minikube
       uses: metalbear-co/setup-minikube@3fa06c2257eb48a3ca8e24fedece59ee2479255a


### PR DESCRIPTION
metalbear-co/mirrord/pull/3570 requires C test apps for E2E tests.